### PR TITLE
CCI Config Helper - increase resource class size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ orbs:
   python: circleci/python@2.1.1
 jobs:
   build-and-test:
-    resource_class: small
+    resource_class: large
     docker:
       - image: cimg/python:3.11.0
     parallelism: 3


### PR DESCRIPTION
Hi 👋! We noticed that this job: **[build-and-test](https://app.circleci.com/pipelines/github/sebastian-lerner/testing-flask-pytest/33/workflows/f4b25a1e-eb07-4bb4-991b-1efb4641725b/jobs/34)** has hit **> 90% CPU usage in [6 of the last 7 runs](https://app.circleci.com/insights/github/sebastian-lerner/testing-flask-pytest/workflows/sample/jobs?branch=main&job-name=build-and-test&reporting-window=last-90-days)**.

![image](https://user-images.githubusercontent.com/123413163/214138431-4a92651c-7cd3-4bb7-a8cc-e0dfc2c50906.png)

This pull request enables a larger [resource class](https://circleci.com/docs/configuration-reference/#resourceclass) which should reduce your CPU usage and **make your job run faster** 🚀

Questions about how this PR got created? See our [Community Forum](https://discuss.circleci.com/). Want to opt out of future config suggestions? [Click here](google.com).  Happy building!

